### PR TITLE
[#4] Fix on GetDatabase function

### DIFF
--- a/database.go
+++ b/database.go
@@ -9,17 +9,22 @@ import (
 
 /*
 GetDatabase returns database connected to a programmatically defined database connection.
-It throws an error if connection fails in a Fatal manner, because database connection is essential to almost any backend
+It not throws an error if connection fails in a Fatal manner
+But this function will wait 1 second before retrying to connect to db again
+Because database connection is essential to almost any backend
 */
 func GetDatabase(dbAddress string, dbUsername string, dbPassword string, dbName string) *sql.DB {
 	log.Printf("INFO GetDatabase database connection: starting database connection process")
 
 	dataSourceName := fmt.Sprintf("%s:%s@tcp(%s)/%s?parseTime=true",
-		dbUsername, dbPassword, dbAddress, dbName)
+																dbUsername, dbPassword, dbAddress, dbName)
 
-	var db *sql.DB
+	var (
+		db *sql.DB
+		err error
+	)
 	for {
-		db, err := sql.Open("mysql", dataSourceName)
+		db, err = sql.Open("mysql", dataSourceName)
 		if pingErr := db.Ping(); err != nil || pingErr != nil {
 			if err != nil {
 				log.Printf("ERROR GetDatabase sql open connection fatal error: %v\n", err)

--- a/database.go
+++ b/database.go
@@ -17,7 +17,7 @@ func GetDatabase(dbAddress string, dbUsername string, dbPassword string, dbName 
 	log.Printf("INFO GetDatabase database connection: starting database connection process")
 
 	dataSourceName := fmt.Sprintf("%s:%s@tcp(%s)/%s?parseTime=true",
-																dbUsername, dbPassword, dbAddress, dbName)
+		dbUsername, dbPassword, dbAddress, dbName)
 
 	var (
 		db *sql.DB


### PR DESCRIPTION
We have some panic runtime error on GetDatabase function because of `:=` on looping on open the database connection. Because of that, i declare the `err` variable outside the scope too.

![Screenshot from 2022-05-05 00-18-32](https://user-images.githubusercontent.com/51501141/166725722-2c01a187-36b1-4445-9823-2c7f41735d4f.png)

Sorry for the additional commit :"